### PR TITLE
3-do-not-check-for-the-result-of-json-encode-in-the-can-manipulate-json-trait

### DIFF
--- a/src/Traits/CanManipulateJson.php
+++ b/src/Traits/CanManipulateJson.php
@@ -4,8 +4,6 @@ declare(strict_types = 1);
 
 namespace Folded\Traits;
 
-use JsonException;
-
 /**
  * Centralize methods to encode/decode a JSON string.
  *
@@ -18,8 +16,6 @@ trait CanManipulateJson
      *
      * @param array<mixed> $data An array representing the JSON data.
      *
-     * @throws JsonException if an error occurs while converting the array into JSON string.
-     *
      * @since 0.1.0
      *
      * @example
@@ -27,24 +23,13 @@ trait CanManipulateJson
      */
     public static function arrayToJsonString(array $data): string
     {
-        $jsonString = json_encode($data, JSON_THROW_ON_ERROR);
-
-        // Ignoring because it might be a bug on phpstan
-        // see: https://github.com/phpstan/phpstan/issues/3934
-        // @phpstan-ignore-next-line
-        if ($jsonString === false) {
-            throw new JsonException(json_last_error_msg());
-        }
-
-        return $jsonString;
+        return json_encode($data, JSON_THROW_ON_ERROR);
     }
 
     /**
      * Returns an array from a JSON string.
      *
      * @param string $jsonString The JSON string.
-     *
-     * @throws JsonException If an error occurs while parsing the JSON string.
      *
      * @return array<mixed>
      *
@@ -55,15 +40,6 @@ trait CanManipulateJson
      */
     public static function jsonStringToArray(string $jsonString): array
     {
-        $jsonArray = json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR);
-
-        // Ignoring because it might be a bug on phpstan
-        // see: https://github.com/phpstan/phpstan/issues/3934
-        // @phpstan-ignore-next-line
-        if ($jsonArray === false || $jsonArray === null) {
-            throw new JsonException("cannot decode json string");
-        }
-
-        return $jsonArray;
+        return json_decode($jsonString, true, 512, JSON_THROW_ON_ERROR);
     }
 }


### PR DESCRIPTION
## Added

None.

## Fixed

- Not checking the return of `json_encode()` and `json_decode()` calls (because we use `JSON_THROW_ON_ERROR`.

## Breaking

None.